### PR TITLE
Refactor to make more flexible

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ go get github.com/JosiahWitt/erk
 Erk allows you to create errors that have a kind, message template, and params.
 
 It is recommended to define your error kind types in each package.
-This allows `erk.ToCopy` or `erk.GetKindString` to contain which package the error kind was defined, and therefore, where the error originated.
+This allows `erk.Export` or `erk.GetKindString` to contain which package the error kind was defined, and therefore, where the error originated.
 
 ## Example
 
@@ -52,7 +52,7 @@ This allows `erk.ToCopy` or `erk.GetKindString` to contain which package the err
   func main() {
     err := store.Read("my_table", "", nil)
 
-    bytes, _ := json.MarshalIndent(erk.ToCopy(err), "", "  ")
+    bytes, _ := json.MarshalIndent(erk.Export(err), "", "  ")
     fmt.Println(string(bytes))
 
     fmt.Println()

--- a/erk.go
+++ b/erk.go
@@ -1,0 +1,32 @@
+// Package erk defines errors with kinds for Go 1.13+.
+package erk
+
+import "errors"
+
+// Erkable errors that have Params and a Kind.
+type Erkable interface {
+	Paramable
+	Kindable
+	error
+}
+
+// Wrap an error with a kind and message.
+func Wrap(kind Kind, message string, err error) error {
+	return WrapAs(New(kind, message), err)
+}
+
+// WrapAs wraps an error as an erkError.
+func WrapAs(erkError error, err error) error {
+	return WithParam(erkError, OriginalErrorParam, err)
+}
+
+// ToErk converts an error to an erk.Erkable by wrapping it in an erk.Error.
+// If it is already an erk.Erkable, it returns the error without wrapping it.
+func ToErk(err error) Erkable {
+	var e Erkable
+	if errors.As(err, &e) {
+		return e
+	}
+
+	return Wrap(nil, err.Error(), err).(Erkable)
+}

--- a/erk.go
+++ b/erk.go
@@ -3,10 +3,11 @@ package erk
 
 import "errors"
 
-// Erkable errors that have Params and a Kind.
+// Erkable errors that have Params and a Kind, and can be exported.
 type Erkable interface {
 	Paramable
 	Kindable
+	Exportable
 	error
 }
 

--- a/erk_test.go
+++ b/erk_test.go
@@ -1,0 +1,56 @@
+package erk_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/JosiahWitt/erk"
+	"github.com/matryer/is"
+)
+
+func TestWrap(t *testing.T) {
+	is := is.New(t)
+
+	errWrapped := errors.New("hey")
+	msg := "my message"
+	err := erk.Wrap(ErkExample{}, msg, errWrapped)
+
+	is.Equal(err.Error(), msg)
+	is.Equal(erk.GetParams(err), erk.Params{"err": errWrapped})
+	is.Equal(erk.GetKind(err), ErkExample{})
+	is.Equal(errors.Unwrap(err), errWrapped)
+}
+
+func TestWrapAs(t *testing.T) {
+	is := is.New(t)
+
+	errWrapped := errors.New("hey")
+	msg := "my message"
+	errWrapper := erk.New(ErkExample{}, msg)
+	err := erk.WrapAs(errWrapper, errWrapped)
+
+	is.Equal(err.Error(), msg)
+	is.Equal(erk.GetParams(err), erk.Params{"err": errWrapped})
+	is.Equal(erk.GetKind(err), ErkExample{})
+	is.Equal(errors.Unwrap(err), errWrapped)
+}
+
+func TestToErk(t *testing.T) {
+	t.Run("with erk.Erkable", func(t *testing.T) {
+		is := is.New(t)
+
+		err := erk.New(ErkExample{}, "my message")
+		is.Equal(erk.ToErk(err), err)
+	})
+
+	t.Run("with non erk.Erkable", func(t *testing.T) {
+		is := is.New(t)
+
+		msg := "the message"
+		originalErr := errors.New(msg)
+		wrappedErr := erk.ToErk(originalErr)
+		expectedErr := erk.Wrap(nil, msg, originalErr)
+		is.Equal(wrappedErr, expectedErr)
+		is.Equal(erk.GetKind(wrappedErr), nil)
+	})
+}

--- a/error.go
+++ b/error.go
@@ -7,11 +7,15 @@ import (
 	"html/template"
 )
 
-// Error satisfies the following interfaces:
-var (
-	_ Paramable = &Error{}
-	_ error     = &Error{}
-)
+// Error satisfies the Erkable interface.
+var _ Erkable = &Error{}
+
+// Erkable errors that have Params and a Kind.
+type Erkable interface {
+	Paramable
+	Kindable
+	error
+}
 
 // Error stores details about an error with kinds and a message template.
 type Error struct {
@@ -82,6 +86,12 @@ func (e *Error) Unwrap() error {
 	}
 
 	return nil
+}
+
+// Kind of the Error.
+// See Kind for more details.
+func (e *Error) Kind() Kind {
+	return e.kind
 }
 
 // WithParams adds parameters to a copy of the Error.

--- a/error.go
+++ b/error.go
@@ -1,4 +1,3 @@
-// Package erk defines errors with kinds for Go 1.13+.
 package erk
 
 import (
@@ -9,13 +8,6 @@ import (
 
 // Error satisfies the Erkable interface.
 var _ Erkable = &Error{}
-
-// Erkable errors that have Params and a Kind.
-type Erkable interface {
-	Paramable
-	Kindable
-	error
-}
 
 // Error stores details about an error with kinds and a message template.
 type Error struct {
@@ -132,32 +124,11 @@ func (e *Error) Params() Params {
 	return paramsCopy
 }
 
-// Wrap an error with a kind and message.
-func Wrap(kind Kind, message string, err error) error {
-	return WrapAs(New(kind, message), err)
-}
-
-// WrapAs wraps an error as an erkError.
-func WrapAs(erkError error, err error) error {
-	return WithParam(erkError, OriginalErrorParam, err)
-}
-
-// ToError converts an error to an erk.Error by wrapping it.
-// If it is already an erk.Error, it returns the error without wrapping it.
-func ToError(err error) *Error {
-	var e *Error
-	if errors.As(err, &e) {
-		return e
-	}
-
-	return Wrap(nil, err.Error(), err).(*Error)
-}
-
 // ToCopy creates a visible copy of the error that can be used outside the erk package.
 // A common use case is marshalling the error to JSON.
 // If err is not an erk.Error, it is wrapped first.
 func ToCopy(err error) *ErrorCopy {
-	e := ToError(err)
+	e := ToErk(err)
 
 	return &ErrorCopy{
 		Kind:    GetKindString(e),

--- a/error.go
+++ b/error.go
@@ -16,12 +16,10 @@ type Error struct {
 	params  Params
 }
 
-// ErrorCopy represents a copy of the error.
-// A common use case is marshalling to JSON.
-type ErrorCopy struct {
-	Kind    string `json:"kind"`
-	Message string `json:"message"`
-	Params  Params `json:"params,omitempty"`
+// ExportedError that can be used outside the erk package.
+// A common use case is marshalling the error to JSON.
+type ExportedError struct {
+	BaseExport
 }
 
 // New creates an error with a kind and message.
@@ -124,16 +122,15 @@ func (e *Error) Params() Params {
 	return paramsCopy
 }
 
-// ToCopy creates a visible copy of the error that can be used outside the erk package.
+// Export creates a visible copy of the Error that can be used outside the erk package.
 // A common use case is marshalling the error to JSON.
-// If err is not an erk.Error, it is wrapped first.
-func ToCopy(err error) *ErrorCopy {
-	e := ToErk(err)
-
-	return &ErrorCopy{
-		Kind:    GetKindString(e),
-		Message: e.Error(),
-		Params:  GetParams(e),
+func (e *Error) Export() ExportedErkable {
+	return &ExportedError{
+		BaseExport: BaseExport{
+			Kind:    GetKindString(e),
+			Message: e.Error(),
+			Params:  GetParams(e),
+		},
 	}
 }
 

--- a/error_test.go
+++ b/error_test.go
@@ -206,53 +206,6 @@ func TestErrorParams(t *testing.T) {
 	})
 }
 
-func TestWrap(t *testing.T) {
-	is := is.New(t)
-
-	errWrapped := errors.New("hey")
-	msg := "my message"
-	err := erk.Wrap(ErkExample{}, msg, errWrapped)
-
-	is.Equal(err.Error(), msg)
-	is.Equal(erk.GetParams(err), erk.Params{"err": errWrapped})
-	is.Equal(erk.GetKind(err), ErkExample{})
-	is.Equal(errors.Unwrap(err), errWrapped)
-}
-
-func TestWrapAs(t *testing.T) {
-	is := is.New(t)
-
-	errWrapped := errors.New("hey")
-	msg := "my message"
-	errWrapper := erk.New(ErkExample{}, msg)
-	err := erk.WrapAs(errWrapper, errWrapped)
-
-	is.Equal(err.Error(), msg)
-	is.Equal(erk.GetParams(err), erk.Params{"err": errWrapped})
-	is.Equal(erk.GetKind(err), ErkExample{})
-	is.Equal(errors.Unwrap(err), errWrapped)
-}
-
-func TestToError(t *testing.T) {
-	t.Run("with erk.Error", func(t *testing.T) {
-		is := is.New(t)
-
-		err := erk.New(ErkExample{}, "my message")
-		is.Equal(erk.ToError(err), err)
-	})
-
-	t.Run("with non erk.Error", func(t *testing.T) {
-		is := is.New(t)
-
-		msg := "the message"
-		originalErr := errors.New(msg)
-		wrappedErr := erk.ToError(originalErr)
-		expectedErr := erk.Wrap(nil, msg, originalErr)
-		is.Equal(wrappedErr, expectedErr)
-		is.Equal(erk.GetKind(wrappedErr), nil)
-	})
-}
-
 func TestToCopy(t *testing.T) {
 	t.Run("with valid params", func(t *testing.T) {
 		is := is.New(t)

--- a/error_test.go
+++ b/error_test.go
@@ -137,6 +137,68 @@ func TestUnwrap(t *testing.T) {
 	})
 }
 
+func TestErrorWithParams(t *testing.T) {
+	t.Run("with nil params, setting nil params", func(t *testing.T) {
+		is := is.New(t)
+
+		err1 := erk.New(ErkExample{}, "my message")
+		err2 := err1.(*erk.Error).WithParams(nil)
+		is.Equal(err2, err1)
+		is.Equal(err2.(*erk.Error).Params(), nil)
+	})
+
+	t.Run("with nil params, setting two params", func(t *testing.T) {
+		is := is.New(t)
+
+		err := erk.New(ErkExample{}, "my message")
+		err = err.(*erk.Error).WithParams(erk.Params{"a": "hello", "b": "world"})
+		is.Equal(err.(*erk.Error).Params(), erk.Params{"a": "hello", "b": "world"})
+	})
+
+	t.Run("with present params, setting nil params", func(t *testing.T) {
+		is := is.New(t)
+
+		err1 := erk.NewWith(ErkExample{}, "my message", erk.Params{"0": "hey", "1": "there"})
+		err2 := err1.(*erk.Error).WithParams(nil)
+		is.Equal(err2, err1)
+		is.Equal(err2.(*erk.Error).Params(), erk.Params{"0": "hey", "1": "there"})
+	})
+
+	t.Run("with present params, setting two params", func(t *testing.T) {
+		is := is.New(t)
+
+		err := erk.NewWith(ErkExample{}, "my message", erk.Params{"0": "hey", "1": "there"})
+		err = err.(*erk.Error).WithParams(erk.Params{"a": "hello", "b": "world"})
+		is.Equal(err.(*erk.Error).Params(), erk.Params{"0": "hey", "1": "there", "a": "hello", "b": "world"})
+	})
+
+	t.Run("with present params, deleting one param", func(t *testing.T) {
+		is := is.New(t)
+
+		err := erk.NewWith(ErkExample{}, "my message", erk.Params{"0": "hey", "1": "there"})
+		err = err.(*erk.Error).WithParams(erk.Params{"a": "hello", "b": "world", "1": nil})
+		is.Equal(err.(*erk.Error).Params(), erk.Params{"0": "hey", "a": "hello", "b": "world"})
+	})
+}
+
+func TestErrorParams(t *testing.T) {
+	t.Run("returns parameters", func(t *testing.T) {
+		is := is.New(t)
+
+		err := erk.NewWith(ErkExample{}, "my message", erk.Params{"0": "hey", "1": "there"})
+		is.Equal(err.(*erk.Error).Params(), erk.Params{"0": "hey", "1": "there"})
+	})
+
+	t.Run("returns a copy of the parameters", func(t *testing.T) {
+		is := is.New(t)
+
+		err := erk.NewWith(ErkExample{}, "my message", erk.Params{"0": "hey", "1": "there"})
+		params := err.(*erk.Error).Params()
+		params["0"] = "changed"
+		is.Equal(err.(*erk.Error).Params(), erk.Params{"0": "hey", "1": "there"})
+	})
+}
+
 func TestWrap(t *testing.T) {
 	is := is.New(t)
 

--- a/error_test.go
+++ b/error_test.go
@@ -137,6 +137,13 @@ func TestUnwrap(t *testing.T) {
 	})
 }
 
+func TestErrorKind(t *testing.T) {
+	is := is.New(t)
+
+	err := erk.New(ErkExample{}, "my message")
+	is.Equal(err.(*erk.Error).Kind(), ErkExample{})
+}
+
 func TestErrorWithParams(t *testing.T) {
 	t.Run("with nil params, setting nil params", func(t *testing.T) {
 		is := is.New(t)

--- a/error_test.go
+++ b/error_test.go
@@ -206,14 +206,14 @@ func TestErrorParams(t *testing.T) {
 	})
 }
 
-func TestToCopy(t *testing.T) {
+func TestErrorExport(t *testing.T) {
 	t.Run("with valid params", func(t *testing.T) {
 		is := is.New(t)
 
 		val := "the world"
 		err := erk.New(ErkExample{}, "my message: {{.a}}")
 		err = erk.WithParam(err, "a", val)
-		errc := erk.ToCopy(err)
+		errc := err.(*erk.Error).Export().(*erk.ExportedError)
 		is.Equal(errc.Kind, "github.com/JosiahWitt/erk_test:ErkExample")
 		is.Equal(errc.Message, "my message: the world")
 		is.Equal(errc.Params, erk.Params{"a": "the world"})
@@ -225,20 +225,9 @@ func TestToCopy(t *testing.T) {
 		val := "the world"
 		err := erk.New(ErkExample{}, "my message: {{.a}}")
 		err = erk.WithParam(err, "a", val)
-		errc := erk.ToCopy(err)
+		errc := err.(*erk.Error).Export().(*erk.ExportedError)
 		errc.Params["a"] = "123"
 		is.Equal(erk.GetParams(err), erk.Params{"a": "the world"})
-	})
-
-	t.Run("with non erk.Error", func(t *testing.T) {
-		is := is.New(t)
-
-		msg := "hey there"
-		err := errors.New(msg)
-		errc := erk.ToCopy(err)
-		is.Equal(errc.Kind, "")
-		is.Equal(errc.Message, msg)
-		is.Equal(errc.Params, erk.Params{"err": err})
 	})
 
 	t.Run("to JSON", func(t *testing.T) {
@@ -248,7 +237,7 @@ func TestToCopy(t *testing.T) {
 			val := "the world"
 			err := erk.New(ErkExample{}, "my message: {{.a}}")
 			err = erk.WithParam(err, "a", val)
-			errc := erk.ToCopy(err)
+			errc := err.(*erk.Error).Export().(*erk.ExportedError)
 			b, jerr := json.Marshal(errc)
 			is.NoErr(jerr)
 			is.Equal(string(b), `{"kind":"github.com/JosiahWitt/erk_test:ErkExample","message":"my message: the world","params":{"a":"the world"}}`)
@@ -258,7 +247,7 @@ func TestToCopy(t *testing.T) {
 			is := is.New(t)
 
 			err := erk.New(ErkExample{}, "my message")
-			errc := erk.ToCopy(err)
+			errc := err.(*erk.Error).Export().(*erk.ExportedError)
 			b, jerr := json.Marshal(errc)
 			is.NoErr(jerr)
 			is.Equal(string(b), `{"kind":"github.com/JosiahWitt/erk_test:ErkExample","message":"my message"}`)

--- a/export.go
+++ b/export.go
@@ -1,0 +1,42 @@
+package erk
+
+// ExportedErkable is an exported readonly version of the Erkable interface.
+type ExportedErkable interface {
+	ErrorMessage() string
+	ErrorKind() string
+	ErrorParams() Params
+}
+
+// Exportable errors that support being exported to a JSON marshal friendly format.
+type Exportable interface {
+	Export() ExportedErkable
+}
+
+// BaseExport error that satisfies the ExportedErkable interface and is useful for JSON marshalling.
+type BaseExport struct {
+	Kind    string `json:"kind"`
+	Message string `json:"message"`
+	Params  Params `json:"params,omitempty"`
+}
+
+// ErrorMessage returns the error message.
+func (e *BaseExport) ErrorMessage() string {
+	return e.Message
+}
+
+// ErrorKind returns the error kind.
+func (e *BaseExport) ErrorKind() string {
+	return e.Kind
+}
+
+// ErrorParams returns the error params.
+func (e *BaseExport) ErrorParams() Params {
+	return e.Params
+}
+
+// Export creates a visible copy of the error that can be used outside the erk package.
+// A common use case is marshalling the error to JSON.
+// If err is not an erk.Erkable, it is wrapped first.
+func Export(err error) ExportedErkable {
+	return ToErk(err).Export()
+}

--- a/export_test.go
+++ b/export_test.go
@@ -1,0 +1,58 @@
+package erk_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/JosiahWitt/erk"
+	"github.com/matryer/is"
+)
+
+func TestBaseExportErrorMessage(t *testing.T) {
+	is := is.New(t)
+
+	message := "my message"
+	export := &erk.BaseExport{Message: message}
+	is.Equal(export.ErrorMessage(), message)
+}
+
+func TestBaseExportErrorKind(t *testing.T) {
+	is := is.New(t)
+
+	kind := "my kind"
+	export := &erk.BaseExport{Kind: kind}
+	is.Equal(export.ErrorKind(), kind)
+}
+
+func TestBaseExportErrorParams(t *testing.T) {
+	is := is.New(t)
+
+	params := erk.Params{"my": "params"}
+	export := &erk.BaseExport{Params: params}
+	is.Equal(export.ErrorParams(), params)
+}
+
+func TestExport(t *testing.T) {
+	t.Run("with erk.Error", func(t *testing.T) {
+		is := is.New(t)
+
+		val := "the world"
+		err := erk.New(ErkExample{}, "my message: {{.a}}")
+		err = erk.WithParam(err, "a", val)
+		errc := erk.Export(err)
+		is.Equal(errc.ErrorKind(), "github.com/JosiahWitt/erk_test:ErkExample")
+		is.Equal(errc.ErrorMessage(), "my message: the world")
+		is.Equal(errc.ErrorParams(), erk.Params{"a": "the world"})
+	})
+
+	t.Run("with non erk.Erkable", func(t *testing.T) {
+		is := is.New(t)
+
+		msg := "hey there"
+		err := errors.New(msg)
+		errc := erk.Export(err)
+		is.Equal(errc.ErrorKind(), "")
+		is.Equal(errc.ErrorMessage(), msg)
+		is.Equal(errc.ErrorParams(), erk.Params{"err": err})
+	})
+}

--- a/kind.go
+++ b/kind.go
@@ -36,6 +36,11 @@ type Kind interface{}
 // Example: See Kind.
 type DefaultKind struct{}
 
+// Kindable errors that support housing an error Kind.
+type Kindable interface {
+	Kind() Kind
+}
+
 // IsKind checks if the error's kind is the provided kind.
 func IsKind(err error, kind Kind) bool {
 	return reflect.TypeOf(GetKind(err)) == reflect.TypeOf(kind)
@@ -43,9 +48,9 @@ func IsKind(err error, kind Kind) bool {
 
 // GetKind from the provided error.
 func GetKind(err error) Kind {
-	var e *Error
-	if errors.As(err, &e) {
-		return e.kind
+	var k Kindable
+	if errors.As(err, &k) {
+		return k.Kind()
 	}
 
 	return nil

--- a/kind_test.go
+++ b/kind_test.go
@@ -2,51 +2,84 @@ package erk_test
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/JosiahWitt/erk"
 	"github.com/matryer/is"
 )
 
+type TestKindable struct {
+	kind erk.Kind
+}
+
+func (k *TestKindable) Kind() erk.Kind {
+	return k.kind
+}
+
+func (k *TestKindable) Error() string {
+	return fmt.Sprintf("%T", k.kind)
+}
+
 func TestIsKind(t *testing.T) {
-	t.Run("with equal kind", func(t *testing.T) {
-		is := is.New(t)
+	t.Run("with erk.Kindable", func(t *testing.T) {
+		t.Run("with equal kind", func(t *testing.T) {
+			is := is.New(t)
 
-		err := erk.New(ErkExample{}, "my message")
-		is.True(erk.IsKind(err, ErkExample{}))
+			err := &TestKindable{kind: ErkExample{}}
+			is.True(erk.IsKind(err, ErkExample{}))
+		})
+
+		t.Run("with non equal kind", func(t *testing.T) {
+			is := is.New(t)
+
+			err := &TestKindable{kind: ErkExample{}}
+			is.Equal(erk.IsKind(err, ErkExample2{}), false)
+		})
 	})
 
-	t.Run("with non equal kind", func(t *testing.T) {
-		is := is.New(t)
+	t.Run("with erk.Error", func(t *testing.T) {
+		t.Run("with equal kind", func(t *testing.T) {
+			is := is.New(t)
 
-		err := erk.New(ErkExample{}, "my message")
-		is.Equal(erk.IsKind(err, ErkExample2{}), false)
+			err := erk.New(ErkExample{}, "my message")
+			is.True(erk.IsKind(err, ErkExample{}))
+		})
+
+		t.Run("with non equal kind", func(t *testing.T) {
+			is := is.New(t)
+
+			err := erk.New(ErkExample{}, "my message")
+			is.Equal(erk.IsKind(err, ErkExample2{}), false)
+		})
 	})
 
-	t.Run("with non erk.Error not equal", func(t *testing.T) {
-		is := is.New(t)
+	t.Run("with non erk.Kindable", func(t *testing.T) {
+		t.Run("with not equal kind", func(t *testing.T) {
+			is := is.New(t)
 
-		err := errors.New("abc")
-		is.Equal(erk.IsKind(err, ErkExample{}), false)
-	})
+			err := errors.New("abc")
+			is.Equal(erk.IsKind(err, ErkExample{}), false)
+		})
 
-	t.Run("with non erk.Error equal", func(t *testing.T) {
-		is := is.New(t)
+		t.Run("with equal kind", func(t *testing.T) {
+			is := is.New(t)
 
-		err := errors.New("abc")
-		is.True(erk.IsKind(err, nil))
+			err := errors.New("abc")
+			is.True(erk.IsKind(err, nil))
+		})
 	})
 }
 
 func TestGetKind(t *testing.T) {
-	t.Run("with kind", func(t *testing.T) {
+	t.Run("with erk.Kindable", func(t *testing.T) {
 		is := is.New(t)
 
-		err := erk.New(ErkExample{}, "my message")
+		err := &TestKindable{kind: ErkExample{}}
 		is.Equal(erk.GetKind(err), ErkExample{})
 	})
 
-	t.Run("with non erk.Error", func(t *testing.T) {
+	t.Run("with non erk.Kindable", func(t *testing.T) {
 		is := is.New(t)
 
 		err := errors.New("abc")
@@ -55,14 +88,14 @@ func TestGetKind(t *testing.T) {
 }
 
 func TestGetKindString(t *testing.T) {
-	t.Run("with kind", func(t *testing.T) {
+	t.Run("with erk.Kindable", func(t *testing.T) {
 		is := is.New(t)
 
-		err := erk.New(ErkExample{}, "my message")
+		err := &TestKindable{kind: ErkExample{}}
 		is.Equal(erk.GetKindString(err), "github.com/JosiahWitt/erk_test:ErkExample")
 	})
 
-	t.Run("with non erk.Error", func(t *testing.T) {
+	t.Run("with non erk.Kindable", func(t *testing.T) {
 		is := is.New(t)
 
 		err := errors.New("abc")

--- a/params.go
+++ b/params.go
@@ -2,6 +2,12 @@ package erk
 
 import "errors"
 
+// Paramable errors that support appending Params and getting Params.
+type Paramable interface {
+	WithParams(params Params) error
+	Params() Params
+}
+
 // OriginalErrorParam is the param key that contains the wrapped error.
 //
 // This allows the original error to be used in message templates.
@@ -11,55 +17,38 @@ const OriginalErrorParam = "err"
 // Params are key value parameters that are usuable in the message template.
 type Params map[string]interface{}
 
-// WithParams on a copy of the error.
+// WithParams adds parameters to an error.
 //
-// If err is not an erk.Error, it is converted to one first by calling erk.ToError.
+// If err does not satisfy Paramable, the original error is returned.
 // A nil param value deletes the param key.
 func WithParams(err error, params Params) error {
 	if len(params) == 0 {
 		return err
 	}
 
-	e := clone(err)
-	if e.params == nil {
-		e.params = Params{}
+	var p Paramable
+	if errors.As(err, &p) {
+		return p.WithParams(params)
 	}
 
-	for key, value := range params {
-		if value == nil {
-			delete(e.params, key)
-		} else {
-			e.params[key] = value
-		}
-	}
-
-	return e
+	return err
 }
 
-// WithParam on a copy of the error.
+// WithParam adds a parameter to an error.
 //
-// If err is not an erk.Error, it is converted to one first by calling erk.ToError.
+// If err does not satisfy Paramable, the original error is returned.
 // A nil param value deletes the param key.
 func WithParam(err error, key string, value interface{}) error {
 	return WithParams(err, Params{key: value})
 }
 
-// GetParams returns a copy of the error's parameters.
+// GetParams returns the error's parameters.
 //
-// If no parameters have been set, or err is not an erk.Error, nil is returned.
+// If err does not satisfy Paramable, nil is returned.
 func GetParams(err error) Params {
-	var e *Error
-	if errors.As(err, &e) {
-		if e.params == nil {
-			return nil
-		}
-
-		paramsCopy := Params{}
-		for k, v := range e.params {
-			paramsCopy[k] = v
-		}
-
-		return paramsCopy
+	var p Paramable
+	if errors.As(err, &p) {
+		return p.Params()
 	}
 
 	return nil

--- a/params_test.go
+++ b/params_test.go
@@ -2,128 +2,119 @@ package erk_test
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/JosiahWitt/erk"
 	"github.com/matryer/is"
 )
 
+var _ erk.Paramable = &TestParamable{}
+
+type TestParamable struct {
+	params erk.Params
+}
+
+func (p *TestParamable) Error() string {
+	return fmt.Sprint(p)
+}
+
+func (p *TestParamable) WithParams(params erk.Params) error {
+	p.params = params
+	return p
+}
+
+func (p *TestParamable) Params() erk.Params {
+	return p.params
+}
+
 func TestWithParams(t *testing.T) {
-	t.Run("with erk.Error", func(t *testing.T) {
-		t.Run("with nil params, setting nil params", func(t *testing.T) {
+	t.Run("with erk.Paramable", func(t *testing.T) {
+		t.Run("setting empty params", func(t *testing.T) {
 			is := is.New(t)
 
-			err1 := erk.New(ErkExample{}, "my message")
-			err2 := erk.WithParams(err1, nil)
+			err1 := &TestParamable{}
+			err2 := erk.WithParams(err1, erk.Params{})
+			is.Equal(err1.params, nil)
 			is.Equal(err2, err1)
-			is.Equal(erk.GetParams(err2), nil)
-		})
-
-		t.Run("with nil params, setting two params", func(t *testing.T) {
-			is := is.New(t)
-
-			err := erk.New(ErkExample{}, "my message")
-			err = erk.WithParams(err, erk.Params{"a": "hello", "b": "world"})
-			is.Equal(erk.GetParams(err), erk.Params{"a": "hello", "b": "world"})
-		})
-
-		t.Run("with present params, setting nil params", func(t *testing.T) {
-			is := is.New(t)
-
-			err1 := erk.NewWith(ErkExample{}, "my message", erk.Params{"0": "hey", "1": "there"})
-			err2 := erk.WithParams(err1, nil)
-			is.Equal(err2, err1)
-			is.Equal(erk.GetParams(err2), erk.Params{"0": "hey", "1": "there"})
-		})
-
-		t.Run("with present params, setting two params", func(t *testing.T) {
-			is := is.New(t)
-
-			err := erk.NewWith(ErkExample{}, "my message", erk.Params{"0": "hey", "1": "there"})
-			err = erk.WithParams(err, erk.Params{"a": "hello", "b": "world"})
-			is.Equal(erk.GetParams(err), erk.Params{"0": "hey", "1": "there", "a": "hello", "b": "world"})
-		})
-
-		t.Run("with present params, deleting one param", func(t *testing.T) {
-			is := is.New(t)
-
-			err := erk.NewWith(ErkExample{}, "my message", erk.Params{"0": "hey", "1": "there"})
-			err = erk.WithParams(err, erk.Params{"a": "hello", "b": "world", "1": nil})
-			is.Equal(erk.GetParams(err), erk.Params{"0": "hey", "a": "hello", "b": "world"})
-		})
-	})
-
-	t.Run("with non erk.Error", func(t *testing.T) {
-		t.Run("setting nil params", func(t *testing.T) {
-			is := is.New(t)
-
-			err1 := errors.New("hi")
-			err2 := erk.WithParams(err1, nil)
-			is.Equal(err2, err1)
-			is.Equal(erk.GetParams(err2), nil)
 		})
 
 		t.Run("setting two params", func(t *testing.T) {
 			is := is.New(t)
 
+			err1 := &TestParamable{}
+			err2 := erk.WithParams(err1, erk.Params{"a": "hello", "b": "world"})
+			is.Equal(err1.params, erk.Params{"a": "hello", "b": "world"})
+			is.Equal(err2, err1)
+		})
+	})
+
+	t.Run("with erk.Error", func(t *testing.T) {
+		t.Run("setting two params", func(t *testing.T) {
+			is := is.New(t)
+
+			err := erk.NewWith(ErkExample{}, "my message", erk.Params{"0": "hey", "1": "there"})
+			err = erk.WithParams(err, erk.Params{"a": "hello", "b": "world"})
+			is.Equal(erk.GetParams(err), erk.Params{"0": "hey", "1": "there", "a": "hello", "b": "world"})
+		})
+	})
+
+	t.Run("with non erk.Paramable", func(t *testing.T) {
+		t.Run("setting two params", func(t *testing.T) {
+			is := is.New(t)
+
 			err1 := errors.New("hi")
 			err2 := erk.WithParams(err1, erk.Params{"a": "hello", "b": "world"})
-			is.Equal(erk.GetParams(err2), erk.Params{"a": "hello", "b": "world", "err": err1})
+			is.Equal(erk.GetParams(err2), nil)
 		})
 	})
 }
 
 func TestWithParam(t *testing.T) {
-	t.Run("with erk.Error", func(t *testing.T) {
-		t.Run("with nil params", func(t *testing.T) {
-			is := is.New(t)
+	t.Run("with erk.Paramable", func(t *testing.T) {
+		is := is.New(t)
 
-			err := erk.New(ErkExample{}, "my message")
-			err = erk.WithParam(err, "a", "hello")
-			err = erk.WithParam(err, "b", "world")
-			is.Equal(erk.GetParams(err), erk.Params{"a": "hello", "b": "world"})
-		})
-
-		t.Run("with present params", func(t *testing.T) {
-			is := is.New(t)
-
-			err := erk.NewWith(ErkExample{}, "my message", erk.Params{"0": "hey", "1": "there"})
-			err = erk.WithParam(err, "a", "hello")
-			err = erk.WithParam(err, "b", "world")
-			is.Equal(erk.GetParams(err), erk.Params{"0": "hey", "1": "there", "a": "hello", "b": "world"})
-		})
+		err1 := &TestParamable{}
+		err2 := erk.WithParam(err1, "a", "hello")
+		is.Equal(err1.params, erk.Params{"a": "hello"})
+		is.Equal(err2, err1)
 	})
 
-	t.Run("with non erk.Error", func(t *testing.T) {
+	t.Run("with erk.Error", func(t *testing.T) {
+		is := is.New(t)
+
+		err := erk.NewWith(ErkExample{}, "my message", erk.Params{"0": "hey", "1": "there"})
+		err = erk.WithParam(err, "a", "hello")
+		err = erk.WithParam(err, "b", "world")
+		is.Equal(erk.GetParams(err), erk.Params{"0": "hey", "1": "there", "a": "hello", "b": "world"})
+	})
+
+	t.Run("with non erk.Paramable", func(t *testing.T) {
 		is := is.New(t)
 
 		err1 := errors.New("hi")
 		err2 := erk.WithParam(err1, "a", "hello")
 		err2 = erk.WithParam(err2, "b", "world")
-		is.Equal(erk.GetParams(err2), erk.Params{"a": "hello", "b": "world", "err": err1})
+		is.Equal(erk.GetParams(err2), nil)
 	})
 }
 
 func TestGetParams(t *testing.T) {
-	t.Run("with erk.Error", func(t *testing.T) {
-		t.Run("returns parameters", func(t *testing.T) {
-			is := is.New(t)
+	t.Run("with erk.Paramable", func(t *testing.T) {
+		is := is.New(t)
 
-			err := erk.NewWith(ErkExample{}, "my message", erk.Params{"0": "hey", "1": "there"})
-			is.Equal(erk.GetParams(err), erk.Params{"0": "hey", "1": "there"})
-		})
-
-		t.Run("returns a copy of the parameters", func(t *testing.T) {
-			is := is.New(t)
-
-			err := erk.NewWith(ErkExample{}, "my message", erk.Params{"0": "hey", "1": "there"})
-			params := erk.GetParams(err)
-			params["0"] = "changed"
-			is.Equal(erk.GetParams(err), erk.Params{"0": "hey", "1": "there"})
-		})
+		err := &TestParamable{params: erk.Params{"0": "hey", "1": "there"}}
+		is.Equal(erk.GetParams(err), erk.Params{"0": "hey", "1": "there"})
 	})
 
-	t.Run("with non erk.Error", func(t *testing.T) {
+	t.Run("with erk.Error", func(t *testing.T) {
+		is := is.New(t)
+
+		err := erk.NewWith(ErkExample{}, "my message", erk.Params{"0": "hey", "1": "there"})
+		is.Equal(erk.GetParams(err), erk.Params{"0": "hey", "1": "there"})
+	})
+
+	t.Run("with non erk.Paramable", func(t *testing.T) {
 		is := is.New(t)
 
 		err := errors.New("hi")


### PR DESCRIPTION
## Breaking changes:
- `ToError()` -> `ToErk()`
- `ToCopy()` -> `Export()`