### PR TITLE
Enforce error kinds to have a KindStringFor method (fixes #15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ package store
 import "github.com/JosiahWitt/erk"
 
 type (
-  ErkMissingKey erk.DefaultKind
+  ErkMissingKey struct { erk.DefaultKind }
   ...
 )
 
@@ -93,7 +93,7 @@ package store
 import "github.com/JosiahWitt/erk"
 
 type (
-  ErkMultiRead erk.DefaultKind
+  ErkMultiRead struct { erk.DefaultKind }
   ...
 )
 

--- a/erg/group_test.go
+++ b/erg/group_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/matryer/is"
 )
 
-type MyKind erk.DefaultKind
+type MyKind struct { erk.DefaultKind }
 
 func TestNew(t *testing.T) {
 	is := is.New(t)

--- a/error_test.go
+++ b/error_test.go
@@ -10,8 +10,8 @@ import (
 )
 
 type (
-	ErkExample  erk.DefaultKind
-	ErkExample2 erk.DefaultKind
+	ErkExample  struct { erk.DefaultKind }
+	ErkExample2 struct { erk.DefaultKind }
 )
 
 func TestNew(t *testing.T) {

--- a/kind_test.go
+++ b/kind_test.go
@@ -21,11 +21,9 @@ func (k *TestKindable) Error() string {
 	return fmt.Sprintf("%T", k.kind)
 }
 
-type TestKindStringFor struct{}
+type TestKindStringFor struct{ erk.DefaultKind }
 
-var _ erk.KindStringFor = &TestKindStringFor{}
-
-func (*TestKindStringFor) KindStringFor(k erk.Kind) string {
+func (TestKindStringFor) KindStringFor(k erk.Kind) string {
 	return "my_kind"
 }
 
@@ -106,7 +104,7 @@ func TestGetKindString(t *testing.T) {
 	t.Run("with erk.KindStringFor", func(t *testing.T) {
 		is := is.New(t)
 
-		err := &TestKindable{kind: &TestKindStringFor{}}
+		err := &TestKindable{kind: TestKindStringFor{}}
 		is.Equal(erk.GetKindString(err), "my_kind")
 	})
 


### PR DESCRIPTION
Currently `erk.Kind` is an empty interface, meaning we get no type checking. Let's add `KindStringFor` to that interface, which would be implemented on `erk.DefaultKind`. This switch  requires creating kinds like (and is a breaking change):

```
type ErkMyKind struct { erk.DefaultKind }
```

Using struct embedding is useful for other things, like HTTP statuses, or any other metadata you want to attach to the kind (like marking certain kinds as warnings).