### PR TITLE
Add type template function

### DIFF
--- a/error.go
+++ b/error.go
@@ -53,7 +53,7 @@ func (e *Error) Error() string {
 // The indentLevel represents the indentation of wrapped errors.
 // Thus, it should start with "  ".
 func (e *Error) IndentError(indentLevel string) string {
-	t, err := template.New("").Parse(e.message)
+	t, err := template.New("").Funcs(templateFuncs).Parse(e.message)
 	if err != nil {
 		return e.message
 	}

--- a/template_funcs.go
+++ b/template_funcs.go
@@ -1,0 +1,15 @@
+package erk
+
+import (
+	"fmt"
+	"text/template"
+)
+
+// Functions that are accessible from the error templates.
+var templateFuncs = template.FuncMap{
+	"type": templateFuncType,
+}
+
+func templateFuncType(v interface{}) string {
+	return fmt.Sprintf("%T", v)
+}

--- a/template_funcs_test.go
+++ b/template_funcs_test.go
@@ -1,0 +1,21 @@
+package erk_test
+
+import (
+	"testing"
+
+	"github.com/JosiahWitt/erk"
+	"github.com/matryer/is"
+)
+
+func TestTemplateFuncs(t *testing.T) {
+	t.Run("when printing type of param", func(t *testing.T) {
+		is := is.New(t)
+
+		type TestType string
+
+		msg := "{{.a}} is {{type .a}}"
+		err := erk.New(ErkExample{}, msg)
+		err = erk.WithParam(err, "a", TestType("hello"))
+		is.Equal(err.Error(), "hello is erk_test.TestType")
+	})
+}


### PR DESCRIPTION
Allows printing the type of a param in the template by using the `type` function:

```go
type TestType string

msg := "{{.a}} is {{type .a}}"
err := erk.New(ErkExample{}, msg)
err = erk.WithParam(err, "a", TestType("hello"))
// Results in "hello is mypkg.TestType"
```