### PR TITLE
Upgrade GitHub Actions, include more versions of Go, upgrade linter, and add staticcheck

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,136 @@
+# Erk - Errors with Kinds for Go
+
+## Architecture Overview
+
+Erk is a Go error library that adds structured error kinds, message templating, and parameter storage to standard Go errors while maintaining compatibility with Go 1.13+ `errors.Is` and `errors.Unwrap`.
+
+**Core Components:**
+
+- **erk**: Main package - error creation, wrapping, parameter management
+- **erg**: Error groups - collect multiple errors under a single header error
+- **erkstrict**: Strict mode for development/testing - panics on template/parameter issues
+- **erkmock**: Mock errors for testing without setting required template parameters
+- **erkjson**: JSON export with error kind as type (uses pointer kinds)
+
+## General Instructions
+
+- This is a library, so avoid breaking changes to public APIs unless absolutely necessary.
+- Follow Go conventions and idiomatic patterns.
+- Prioritize simplicity over complexity.
+
+## Error Definition Pattern
+
+**Define error kinds as struct types** embedding `erk.DefaultKind`:
+
+```go
+type ErkMissingKey struct { erk.DefaultKind }
+```
+
+**Define errors as public variables** (not inside functions):
+
+```go
+var ErrMissingReadKey = erk.New(ErkMissingKey{}, "no read key specified for table '{{.tableName}}'")
+```
+
+**Use errors with parameters:**
+
+```go
+return erk.WithParam(ErrMissingReadKey, "tableName", tableName)
+```
+
+This pattern allows consumers to use `errors.Is(err, pkg.ErrMissingReadKey)` regardless of parameter values.
+
+## Message Templates
+
+Error messages use Go `text/template` syntax. Parameters are referenced as `{{.paramName}}`.
+
+**Custom template functions:**
+
+- `{{type .param}}` - returns type of param (like `fmt.Sprintf("%T", ...)`)
+- `{{inspect .param}}` - detailed output (like `fmt.Sprintf("%+v", ...)`)
+
+**Wrapped errors** are accessible in templates via `{{.err}}` (stored in `erk.OriginalErrorParam`).
+
+## Error Groups (erg)
+
+Use `erg` to collect multiple errors:
+
+```go
+groupErr := erg.NewAs(ErrUnableToMultiRead)
+groupErr = erk.WithParam(groupErr, "tableName", tableName)
+for _, key := range keys {
+  groupErr = erg.Append(groupErr, Read(tableName, key, data))
+}
+if erg.Any(groupErr) {  // Check if any errors exist
+  return groupErr
+}
+```
+
+**Important:** Always use `erg.Any()` to conditionally return - prevents returning non-nil empty error groups.
+
+## Strict Mode
+
+**Automatically enabled in tests** (detected via `-test.*` flag) or via `ERK_STRICT_MODE=true` env var.
+
+**Behavior:**
+
+- Panics on invalid templates or missing parameters (instead of silently returning raw template)
+- Validates errors during `errors.Is()` calls (useful for catching issues in tests)
+
+**To disable in tests:** Call `erkstrict.SetStrictMode(false)` in `init()` (see `error_test.go`)
+
+## Testing Patterns
+
+**Use `github.com/JosiahWitt/ensure`** for assertions (project's testing library):
+
+```go
+ensure := ensure.New(t)
+ensure(result).Equals(expected)
+ensure(value).IsTrue()
+ensure.Run("nested test", func(ensure ensurepkg.Ensure) { ... })
+```
+
+**Test error types with `errors.Is()`** - ignores parameters:
+
+```go
+errors.Is(err, store.ErrMissingReadKey)  // true if same error kind + message template
+```
+
+**Mock errors in tests** using `erkmock.From()` to avoid strict mode panics:
+
+```go
+someMockedFunction.Returns(erkmock.From(store.ErrItemNotFound))
+```
+
+## Development Workflow
+
+**Run tests:**
+
+```bash
+go test ./...                                    # All tests
+go test -race -coverprofile=coverage.txt ./...   # With race detector and coverage
+```
+
+**Package naming convention:**
+
+- Test packages use `_test` suffix (e.g., `package erk_test`)
+- Enables testing public API as consumers would use it
+
+**Go version:** Requires Go 1.13+ (uses `errors.Is`, `errors.As`, `errors.Unwrap`)
+
+## Key Interfaces
+
+- `Erkable`: Errors with Params, Kind, and Export capability
+- `Paramable`: Errors that support `WithParams()` and `Params()`
+- `Kindable`: Errors that support `Kind()`
+- `Exportable`: Errors that support `Export()` for JSON marshaling
+
+## Common Patterns
+
+**Creating errors:** Use `erk.New()` or `erk.NewWith()` (for params at creation time)
+
+**Wrapping errors:** Use `erk.WrapAs()` or `erk.WrapWith()` (avoid `erk.Wrap()` - see README recommendations)
+
+**Converting any error to Erk:** Use `erk.ToErk()` - wraps non-Erk errors or returns existing Erk errors unchanged
+
+**Exporting to JSON:** Use `erkjson.Export(err)` to create an error who's value is JSON, or marshal an `erk` error directly to JSON.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,23 +5,38 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        go-version: [1.14, 1.15, 1.16, 1.17, 1.18, 1.19]
+        go-version:
+          [
+            "1.14",
+            "1.15",
+            "1.16",
+            "1.17",
+            "1.18",
+            "1.19",
+            "1.20",
+            "1.21",
+            "1.22",
+            "1.23",
+            "1.24",
+            "1.25",
+          ]
 
     steps:
       - name: Set up Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v5
 
       - name: Test
         run: go test -race -coverprofile=coverage.txt -covermode=atomic ./...
 
       - name: Upload to codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -29,22 +44,34 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        go-version: [1.14, 1.15, 1.16, 1.17, 1.18, 1.19]
+        go-version:
+          [
+            "1.14",
+            "1.15",
+            "1.16",
+            "1.17",
+            "1.18",
+            "1.19",
+            "1.20",
+            "1.21",
+            "1.22",
+            "1.23",
+            "1.24",
+            "1.25",
+          ]
 
     steps:
       - name: Set up Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Check out code
-        uses: actions/checkout@v1
-
-      - name: Install linter
-        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.50.1
+        uses: actions/checkout@v5
 
       - name: Lint
-        run: |
-          export PATH=$PATH:$(go env GOPATH)/bin
-          golangci-lint run
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.5.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,3 +75,27 @@ jobs:
         uses: golangci/golangci-lint-action@v8
         with:
           version: v2.5.0
+
+  staticcheck:
+    name: Staticcheck
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Staticcheck requires Go 1.23+
+        go-version: ["1.23", "1.24", "1.25"]
+
+    steps:
+      - name: Set up Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Check out code
+        uses: actions/checkout@v5
+
+      - name: Staticcheck
+        uses: dominikh/staticcheck-action@v1
+        with:
+          version: "2025.1.1"
+          install-go: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,7 @@
+version: "2"
 linters:
-  enable-all: true
-  fast: false
+  default: all
   disable:
-    - maligned
     - prealloc
     - wsl
     - nlreturn
@@ -12,31 +11,41 @@ linters:
     - exhaustruct
     - ireturn
     - wrapcheck
+    - depguard
+    - embeddedstructfieldcheck
+    - wsl_v5
+    - inamedparam
 
-    # Deprecated:
-    - scopelint
-    - varcheck
-    - ifshort
-    - interfacer
-    - nosnakecase
-    - golint
-    - deadcode
-    - exhaustivestruct
-    - structcheck
+  settings:
+    lll:
+      line-length: 150
 
-linters-settings:
-  lll:
-    line-length: 150
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
 
-issues:
-  exclude-rules:
-    # Exclude some linters from tests
-    - path: _test\.go
-      linters:
-        - funlen
-        - lll
-        - goconst
-        - goerr113
-        - exhaustruct
-        - paralleltest
-        - forcetypeassert
+    rules:
+      # Exclude some linters from tests
+      - path: _test\.go
+        linters:
+          - funlen
+          - lll
+          - goconst
+          - err113
+          - exhaustruct
+          - paralleltest
+          - forcetypeassert
+
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+
+  exclusions:
+    generated: lax

--- a/erkjson/erkjson_test.go
+++ b/erkjson/erkjson_test.go
@@ -72,7 +72,7 @@ func TestExportError(t *testing.T) {
 		Name                string
 		Error               error
 		ExpectedErrorString string
-		TypeCheck           func(ensure ensurepkg.Ensure, entry *Entry, exportedError error)
+		TypeCheck           func(ensure ensurepkg.Ensure, _ *Entry, exportedError error)
 	}
 
 	table := []Entry{
@@ -80,7 +80,7 @@ func TestExportError(t *testing.T) {
 			Name:                "with pointer",
 			Error:               erk.New(&TestPtrWrapableKind{}, "my message"),
 			ExpectedErrorString: `{"kind":"test_ptr_wrapable_kind","message":"my message"}`,
-			TypeCheck: func(ensure ensurepkg.Ensure, entry *Entry, exportedError error) {
+			TypeCheck: func(ensure ensurepkg.Ensure, _ *Entry, exportedError error) {
 				_, ok := exportedError.(*TestPtrWrapableKind)
 				ensure(ok).IsTrue()
 			},
@@ -89,7 +89,7 @@ func TestExportError(t *testing.T) {
 			Name:                "with pointer but not wrapable",
 			Error:               erk.New(&TestPtrNonWrapableKind{}, "my message"),
 			ExpectedErrorString: `{"kind":"test_ptr_non_wrapable_kind","message":"my message"}`,
-			TypeCheck: func(ensure ensurepkg.Ensure, entry *Entry, exportedError error) {
+			TypeCheck: func(ensure ensurepkg.Ensure, _ *Entry, exportedError error) {
 				_, ok := exportedError.(*erkjson.JSONWrapper)
 				ensure(ok).IsTrue()
 			},
@@ -98,7 +98,7 @@ func TestExportError(t *testing.T) {
 			Name:                "with value",
 			Error:               erk.New(TestValueWrapableKind{}, "my message"),
 			ExpectedErrorString: `{"kind":"test_value_wrapable_kind","message":"my message"}`,
-			TypeCheck: func(ensure ensurepkg.Ensure, entry *Entry, exportedError error) {
+			TypeCheck: func(ensure ensurepkg.Ensure, _ *Entry, exportedError error) {
 				_, ok := exportedError.(*erkjson.JSONWrapper) // Since it's a value, it doesn't satisfy the interface
 				ensure(ok).IsTrue()
 			},
@@ -107,7 +107,7 @@ func TestExportError(t *testing.T) {
 			Name:                "with value embedding nil pointer",
 			Error:               erk.New(TestValueWithPtrWrapableKind{}, "my message"),
 			ExpectedErrorString: `{"kind":"test_value_with_ptr_wrapable_kind","message":"my message"}`,
-			TypeCheck: func(ensure ensurepkg.Ensure, entry *Entry, exportedError error) {
+			TypeCheck: func(ensure ensurepkg.Ensure, _ *Entry, exportedError error) {
 				_, ok := exportedError.(*erkjson.JSONWrapper) // Since the pointer is nil, it returns the JSONWrapper type
 				ensure(ok).IsTrue()
 			},
@@ -116,7 +116,7 @@ func TestExportError(t *testing.T) {
 			Name:                "with nil kind",
 			Error:               erk.New(nil, "my message"),
 			ExpectedErrorString: `{"kind":null,"message":"my message"}`,
-			TypeCheck: func(ensure ensurepkg.Ensure, entry *Entry, exportedError error) {
+			TypeCheck: func(ensure ensurepkg.Ensure, _ *Entry, exportedError error) {
 				_, ok := exportedError.(*erkjson.JSONWrapper) // Since the kind is nil, it returns the JSONWrapper type
 				ensure(ok).IsTrue()
 			},
@@ -128,7 +128,7 @@ func TestExportError(t *testing.T) {
 				`"message":"The error cannot be wrapped as JSON: json: error calling MarshalJSON for type *erk.Error: ` +
 				`json: error calling MarshalJSON for type erk.Params: json: unsupported type: chan struct {}"` +
 				`,"params":{"err":"my message"}}`,
-			TypeCheck: func(ensure ensurepkg.Ensure, entry *Entry, exportedError error) {
+			TypeCheck: func(ensure ensurepkg.Ensure, _ *Entry, exportedError error) {
 				_, ok := exportedError.(*TestPtrWrapableKind)
 				ensure(ok).IsTrue()
 			},
@@ -140,7 +140,7 @@ func TestExportError(t *testing.T) {
 			),
 			ExpectedErrorString: `{"kind":"test_ptr_wrapable_kind","message":"my group",` +
 				`"errors":[{"kind":"test_ptr_wrapable_kind","message":"my error"}]}`,
-			TypeCheck: func(ensure ensurepkg.Ensure, entry *Entry, exportedError error) {
+			TypeCheck: func(ensure ensurepkg.Ensure, _ *Entry, exportedError error) {
 				_, ok := exportedError.(*TestPtrWrapableKind)
 				ensure(ok).IsTrue()
 			},
@@ -169,7 +169,7 @@ type TestValueWithPtrWrapableKind struct {
 	*erkjson.JSONWrapper
 }
 
-func (TestValueWithPtrWrapableKind) KindStringFor(kind erk.Kind) string {
+func (TestValueWithPtrWrapableKind) KindStringFor(erk.Kind) string {
 	return "test_value_with_ptr_wrapable_kind"
 }
 
@@ -178,7 +178,7 @@ type TestValueWrapableKind struct {
 	erkjson.JSONWrapper
 }
 
-func (TestValueWrapableKind) KindStringFor(kind erk.Kind) string {
+func (TestValueWrapableKind) KindStringFor(erk.Kind) string {
 	return "test_value_wrapable_kind"
 }
 
@@ -187,7 +187,7 @@ type TestPtrWrapableKind struct {
 	erkjson.JSONWrapper
 }
 
-func (*TestPtrWrapableKind) KindStringFor(kind erk.Kind) string {
+func (*TestPtrWrapableKind) KindStringFor(erk.Kind) string {
 	return "test_ptr_wrapable_kind"
 }
 
@@ -195,6 +195,6 @@ type TestPtrNonWrapableKind struct {
 	erk.DefaultPtrKind
 }
 
-func (*TestPtrNonWrapableKind) KindStringFor(kind erk.Kind) string {
+func (*TestPtrNonWrapableKind) KindStringFor(erk.Kind) string {
 	return "test_ptr_non_wrapable_kind"
 }

--- a/error_export.go
+++ b/error_export.go
@@ -71,7 +71,7 @@ func (e *Error) buildErrorStack() []ExportedErkable {
 
 	for currentErr := errors.Unwrap(e); currentErr != nil; currentErr = errors.Unwrap(currentErr) {
 		// If we converted a regular error to an erk error, don't include the error itself in the error stack
-		//nolint:goerr113 // Our intention is to directly compare the error, not unwrap and compare other errors
+		//nolint:err113 // Our intention is to directly compare the error, not unwrap and compare other errors
 		if e.builtFromRegularError != nil && e.builtFromRegularError == currentErr {
 			continue
 		}

--- a/kind.go
+++ b/kind.go
@@ -97,7 +97,7 @@ func (DefaultKind) KindStringFor(kind Kind) string {
 }
 
 // TemplateFuncsFor the provided kind.
-func (DefaultKind) TemplateFuncsFor(kind Kind) template.FuncMap {
+func (DefaultKind) TemplateFuncsFor(Kind) template.FuncMap {
 	funcMap := make(template.FuncMap, len(defaultTemplateFuncs))
 	for k, v := range defaultTemplateFuncs {
 		funcMap[k] = v

--- a/kind_test.go
+++ b/kind_test.go
@@ -25,7 +25,7 @@ func (k *TestKindable) Error() string {
 
 type TestKindStringFor struct{ erk.DefaultKind }
 
-func (TestKindStringFor) KindStringFor(k erk.Kind) string {
+func (TestKindStringFor) KindStringFor(erk.Kind) string {
 	return "my_kind"
 }
 
@@ -243,15 +243,15 @@ func PointerField(str string) *string {
 
 type KindAsString string
 
+func NewKindAsStringPtr(str string) *KindAsString {
+	k := KindAsString(str)
+	return &k
+}
+
 func (k KindAsString) KindStringFor(erk.Kind) string {
 	return string(k)
 }
 
 func (k KindAsString) String() string {
 	return string(k)
-}
-
-func NewKindAsStringPtr(str string) *KindAsString {
-	k := KindAsString(str)
-	return &k
 }


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Upgrade GitHub Actions to latest versions (setup-go@v6, checkout@v5, codecov-action@v5)

- Expand Go version matrix from 1.14-1.19 to 1.14-1.25 for comprehensive testing

- Add staticcheck linter job for Go 1.23+ with version 2025.1.1

- Upgrade golangci-lint configuration to v2 format with updated linter settings

- Fix unused parameter warnings by replacing named parameters with underscore

- Update linter nolint comment from deprecated goerr113 to err113

- Add Copilot instructions documentation for project architecture and patterns


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub Actions<br/>Upgrade"] --> B["Test & Lint<br/>Jobs"]
  C["Go Version<br/>Matrix"] --> B
  D["Staticcheck<br/>Job"] --> B
  E["Golangci-lint<br/>Config v2"] --> B
  F["Code Cleanup<br/>Unused Params"] --> G["Linter<br/>Compliance"]
  H["Copilot<br/>Instructions"] --> I["Documentation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Upgrade CI workflows and expand Go version coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Upgrade GitHub Actions: setup-go@v2→v6, checkout@v1→v5, <br>codecov-action@v1→v5<br> <li> Expand Go version matrix from 6 versions (1.14-1.19) to 12 versions <br>(1.14-1.25)<br> <li> Add fail-fast: false to test and lint jobs for parallel execution<br> <li> Replace manual golangci-lint installation with <br>golangci/golangci-lint-action@v8<br> <li> Add new staticcheck job for Go 1.23+ using <br>dominikh/staticcheck-action@v1</ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/erk/pull/48/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+64/-13</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>.golangci.yml</strong><dd><code>Migrate golangci-lint config to v2 format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.golangci.yml

<ul><li>Upgrade configuration format from v1 to v2 with new structure<br> <li> Change linters from enable-all to default: all with explicit disables<br> <li> Remove deprecated linters (scopelint, varcheck, ifshort, interfacer, <br>etc.)<br> <li> Add new disabled linters (depguard, embeddedstructfieldcheck, wsl_v5, <br>inamedparam)<br> <li> Reorganize settings with exclusions presets and formatters <br>configuration<br> <li> Update nolint comment from goerr113 to err113 in exclude rules</ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/erk/pull/48/files#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9">+37/-28</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>erkjson_test.go</strong><dd><code>Fix unused parameter warnings in test file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

erkjson/erkjson_test.go

<ul><li>Replace unused parameter <code>entry</code> with underscore in 8 TypeCheck function <br>signatures<br> <li> Replace unused parameter <code>kind</code> with underscore in 4 KindStringFor <br>method signatures<br> <li> Reorder NewKindAsStringPtr function to appear before its usage in <br>KindAsString type</ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/erk/pull/48/files#diff-a5a9055f4ffd108685d5fb10fb2aa4f6b21f3ad2520b749f143c51f2d5208311">+12/-12</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>kind_test.go</strong><dd><code>Fix unused parameter and improve code organization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kind_test.go

<ul><li>Replace unused parameter <code>k</code> with underscore in KindStringFor method <br>signature<br> <li> Reorder NewKindAsStringPtr function to appear before KindAsString <br>methods</ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/erk/pull/48/files#diff-0b08e94f5864c819f6b536b5707e1bb24909969fda9287c057e9df9ec8ae950e">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>error_export.go</strong><dd><code>Update deprecated linter comment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

error_export.go

- Update nolint comment from deprecated goerr113 to err113


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/erk/pull/48/files#diff-9b425686115692d30e601d3625519e484ceb0f25ff967f841586e2e75998aff1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>kind.go</strong><dd><code>Fix unused parameter warning</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kind.go

<ul><li>Replace unused parameter <code>kind</code> with underscore in TemplateFuncsFor <br>method signature</ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/erk/pull/48/files#diff-74ac2fc2bc97ae71af0edc33fca81612593fa6582f0c682ca5448892f15b71eb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>copilot-instructions.md</strong><dd><code>Add Copilot instructions for project architecture</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/copilot-instructions.md

<ul><li>Add comprehensive architecture overview of Erk error library <br>components<br> <li> Document error definition patterns and message template syntax<br> <li> Provide error groups (erg) usage examples and best practices<br> <li> Explain strict mode behavior and testing patterns with ensure library<br> <li> Include development workflow, key interfaces, and common patterns</ul>


</details>


  </td>
  <td><a href="https://github.com/JosiahWitt/erk/pull/48/files#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5">+130/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

